### PR TITLE
EmployeeMapperTest/部署名で該当する従業員の情報を取得できること修正 他、テストデータ修正

### DIFF
--- a/src/test/java/com/yuuki/crudapi/integrationtest/EmployeeRestApiIntegrationTest.java
+++ b/src/test/java/com/yuuki/crudapi/integrationtest/EmployeeRestApiIntegrationTest.java
@@ -51,6 +51,13 @@ public class EmployeeRestApiIntegrationTest {
                            "role": "Staff",
                            "email": "hanako.tanaka@example.com",
                            "phone": "023-4567-8901"
+                       },
+                       {
+                         "name": "Yuki Nakamura",
+                         "department": "HR",
+                         "role": "Specialist",
+                         "email": "yuki.nakamura@example.com",
+                         "phone": "023-4567-8903"
                        }
                    ]
                    
@@ -103,7 +110,7 @@ public class EmployeeRestApiIntegrationTest {
     @DataSet(value = "datasets/Employees.yml")
     @Transactional
     void 存在しない部署名を指定した場合にステータスコードが404を返すこと() throws Exception {
-        String departmentName = "HR";
+        String departmentName = "Research & Development";
         mockMvc.perform(MockMvcRequestBuilders.get("/employees")
                         .param("department", departmentName))
                 .andExpect(MockMvcResultMatchers.status().isNotFound());
@@ -117,7 +124,7 @@ public class EmployeeRestApiIntegrationTest {
         String response = mockMvc.perform(MockMvcRequestBuilders.post("/employees")
                         .contentType(MediaType.APPLICATION_JSON).content("""
                                 {
-                                   "id": 3,
+                                   "id": 4,
                                    "name": "Ichiro Sato",
                                    "birthdate": "1990-03-03",
                                    "department": "Information Systems",

--- a/src/test/java/com/yuuki/crudapi/mapper/EmployeeMapperTest.java
+++ b/src/test/java/com/yuuki/crudapi/mapper/EmployeeMapperTest.java
@@ -30,13 +30,15 @@ public class EmployeeMapperTest {
     void すべてのユーザーが取得できること() {
         List<Employee> employeeList = employeeMapper.findAll();
         assertThat(employeeList)
-                .hasSize(2)
+                .hasSize(3)
                 .usingRecursiveFieldByFieldElementComparator()
                 .contains(
                         new Employee(1, "Taro Yamada", LocalDate.of(1990, 1, 1),
                                 "Sales", "Manager", "taro.yamada@example.com", "012-3456-7890"),
                         new Employee(2, "Hanako Tanaka", LocalDate.of(1995, 2, 2),
-                                "Sales", "Staff", "hanako.tanaka@example.com", "023-4567-8901")
+                                "Sales", "Staff", "hanako.tanaka@example.com", "023-4567-8901"),
+                        new Employee(3, "Yuki Nakamura", LocalDate.of(1992, 4, 4),
+                                "HR", "Specialist", "yuki.nakamura@example.com", "023-4567-8903")
                 );
 
     }
@@ -46,17 +48,22 @@ public class EmployeeMapperTest {
     @Transactional
     void 部署名で該当する従業員の情報を取得できること() {
         List<Employee> result = employeeMapper.findByDepartment("Sales");
-
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getName()).isEqualTo("Taro Yamada");
-        assertThat(result.get(1).getName()).isEqualTo("Hanako Tanaka");
+        assertThat(result)
+                .hasSize(2)
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(
+                        new Employee(1, "Taro Yamada", LocalDate.of(1990, 1, 1),
+                                "Sales", "Manager", "taro.yamada@example.com", "012-3456-7890"),
+                        new Employee(2, "Hanako Tanaka", LocalDate.of(1995, 2, 2),
+                                "Sales", "Staff", "hanako.tanaka@example.com", "023-4567-8901")
+                );
     }
 
     @Test
     @DataSet(value = "datasets/Employees.yml")
     @Transactional
     void 部署名で該当する従業員の情報がないとき空のリストが返される() {
-        List<Employee> result = employeeMapper.findByDepartment("HR");
+        List<Employee> result = employeeMapper.findByDepartment("Research & Development");
         assertThat(result).hasSize(0);
         assertThat(result).isEmpty();
     }
@@ -90,7 +97,7 @@ public class EmployeeMapperTest {
     @ExpectedDataSet(value = "datasets/EmployeesAfterInsert.yml", ignoreCols = "id")
     @Transactional
     void 新しい従業員情報が登録されること() {
-        Employee employee = new Employee(3, "Ichiro Sato", LocalDate.of(1990, 3, 3),
+        Employee employee = new Employee(4, "Ichiro Sato", LocalDate.of(1990, 3, 3),
                 "Information Systems", "System Engineer", "ichiro.sato@example.com", "012-3456-7890");
         employeeMapper.create(employee);
     }

--- a/src/test/resources/datasets/Employees.yml
+++ b/src/test/resources/datasets/Employees.yml
@@ -13,3 +13,17 @@ employees:
     role: "Staff"
     email: "hanako.tanaka@example.com"
     phone: "023-4567-8901"
+  - id: 3
+    name: "Yuki Nakamura"
+    birthdate: "1992-04-04"
+    department: "HR"
+    role: "Specialist"
+    email: "yuki.nakamura@example.com"
+    phone: "023-4567-8903"
+
+
+
+
+
+
+

--- a/src/test/resources/datasets/EmployeesAfterDelete.yml
+++ b/src/test/resources/datasets/EmployeesAfterDelete.yml
@@ -6,4 +6,10 @@ employees:
     role: "Manager"
     email: "taro.yamada@example.com"
     phone: "012-3456-7890"
-
+  - id: 3
+    name: "Yuki Nakamura"
+    birthdate: "1992-04-04"
+    department: "HR"
+    role: "Specialist"
+    email: "yuki.nakamura@example.com"
+    phone: "023-4567-8903"

--- a/src/test/resources/datasets/EmployeesAfterInsert.yml
+++ b/src/test/resources/datasets/EmployeesAfterInsert.yml
@@ -14,6 +14,13 @@ employees:
     email: "hanako.tanaka@example.com"
     phone: "023-4567-8901"
   - id: 3
+    name: "Yuki Nakamura"
+    birthdate: "1992-04-04"
+    department: "HR"
+    role: "Specialist"
+    email: "yuki.nakamura@example.com"
+    phone: "023-4567-8903"
+  - id: 4
     name: "Ichiro Sato"
     birthdate: "1990-03-03"
     department: "Information Systems"

--- a/src/test/resources/datasets/EmployeesAfterUpdate.yml
+++ b/src/test/resources/datasets/EmployeesAfterUpdate.yml
@@ -13,3 +13,10 @@ employees:
     role: "System Engineer"
     email: "hanako.tanaka@example.com"
     phone: "023-4567-8901"
+  - id: 3
+    name: "Yuki Nakamura"
+    birthdate: "1992-04-04"
+    department: "HR"
+    role: "Specialist"
+    email: "yuki.nakamura@example.com"
+    phone: "023-4567-8903"


### PR DESCRIPTION
変更が完了いたしましたので、ご確認をお願いいたします。

・EmployeeMapperTest/部署名で該当する従業員の情報を取得できることに関して
\>すべてのユーザーが取得できること()と同様の検証方法に変更
また、Employees.ymlにてSales以外の部署に所属する従業員データを追加